### PR TITLE
add cleanup function to clean contexts and keys

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ version = "0.1.5-dev"
 OpenFHE = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
 
 [compat]
-OpenFHE = "0.1.9"
+OpenFHE = "0.1.11"
 julia = "1.8"

--- a/examples/simple_ckks_bootstrapping.jl
+++ b/examples/simple_ckks_bootstrapping.jl
@@ -24,6 +24,9 @@ function simple_ckks_bootstrapping(context)
 
     result = decrypt(sv, private_key)
     println("Output after bootstrapping \n\t", result)
+
+    # Clean all `OpenFHE.CryptoContext`s and generated keys.
+    cleanup()
 end
 
 

--- a/examples/simple_ckks_bootstrapping.jl
+++ b/examples/simple_ckks_bootstrapping.jl
@@ -26,7 +26,7 @@ function simple_ckks_bootstrapping(context)
     println("Output after bootstrapping \n\t", result)
 
     # Clean all `OpenFHE.CryptoContext`s and generated keys.
-    cleanup()
+    release_context_memory()
 end
 
 

--- a/examples/simple_ckks_bootstrapping.jl
+++ b/examples/simple_ckks_bootstrapping.jl
@@ -27,6 +27,7 @@ function simple_ckks_bootstrapping(context)
 
     # Clean all `OpenFHE.CryptoContext`s and generated keys.
     release_context_memory()
+    GC.gc()
 end
 
 

--- a/examples/simple_matrix_operations.jl
+++ b/examples/simple_matrix_operations.jl
@@ -70,6 +70,7 @@ function simple_matrix_operations(context)
     
     # Clean all `OpenFHE.CryptoContext`s and generated keys.
     release_context_memory()
+    GC.gc()
 end
 
 

--- a/examples/simple_matrix_operations.jl
+++ b/examples/simple_matrix_operations.jl
@@ -67,6 +67,9 @@ function simple_matrix_operations(context)
 
     result_after_bootstrap = decrypt(sm_after_bootstrap, private_key)
     println("m1 after bootstrapping \n\t", result_after_bootstrap)
+    
+    # Clean all `OpenFHE.CryptoContext`s and generated keys.
+    cleanup()
 end
 
 

--- a/examples/simple_matrix_operations.jl
+++ b/examples/simple_matrix_operations.jl
@@ -69,7 +69,7 @@ function simple_matrix_operations(context)
     println("m1 after bootstrapping \n\t", result_after_bootstrap)
     
     # Clean all `OpenFHE.CryptoContext`s and generated keys.
-    cleanup()
+    release_context_memory()
 end
 
 

--- a/examples/simple_real_numbers.jl
+++ b/examples/simple_real_numbers.jl
@@ -57,7 +57,7 @@ function simple_real_numbers(context)
     println("x1 shifted circularly by 2 = ", result_sv_shift2)
     
     # Clean all `OpenFHE.CryptoContext`s and generated keys.
-    cleanup()
+    release_context_memory()
 end
 
 

--- a/examples/simple_real_numbers.jl
+++ b/examples/simple_real_numbers.jl
@@ -58,6 +58,7 @@ function simple_real_numbers(context)
     
     # Clean all `OpenFHE.CryptoContext`s and generated keys.
     release_context_memory()
+    GC.gc()
 end
 
 

--- a/examples/simple_real_numbers.jl
+++ b/examples/simple_real_numbers.jl
@@ -55,6 +55,9 @@ function simple_real_numbers(context)
 
     result_sv_shift2 = decrypt(sv_shift2, private_key)
     println("x1 shifted circularly by 2 = ", result_sv_shift2)
+    
+    # Clean all `OpenFHE.CryptoContext`s and generated keys.
+    cleanup()
 end
 
 

--- a/src/SecureArithmetic.jl
+++ b/src/SecureArithmetic.jl
@@ -20,7 +20,7 @@ export encrypt, decrypt, decrypt!, bootstrap!
 export level, capacity
 
 # Memory management
-export cleanup
+export release_context_memory
 
 include("types.jl")
 include("operations.jl")

--- a/src/SecureArithmetic.jl
+++ b/src/SecureArithmetic.jl
@@ -19,6 +19,9 @@ export encrypt, decrypt, decrypt!, bootstrap!
 # Query crypto objects
 export level, capacity
 
+# Memory management
+export cleanup
+
 include("types.jl")
 include("operations.jl")
 include("openfhe.jl")

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -72,7 +72,8 @@ Release all `OpenFHE.CryptoContext`s and keys for multiplication, rotation, boot
 
 In the source code of OpenFHE C++, all `CryptoContext`s and keys are stored in static objects.
 Without using `release_context_memory`, the memory allocated for these contexts and keys will
-only be freed after restarting the Julia REPL.
+only be freed after restarting the Julia REPL. It is also advisable to call `GC.gc()` after
+a call to `release_context_memory` to clean up all memory on the Julia side.
 
 See also: [`init_multiplication!`](@ref), [`init_rotation!`](@ref), [`init_bootstrapping!`](@ref)
 """

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -64,19 +64,19 @@ function decrypt(secure_matrix::SecureMatrix, private_key::PrivateKey)
 end
 
 """
-    cleanup()
+    release_context_memory()
 
 Release all `OpenFHE.CryptoContext`s and keys for multiplication, rotation, bootstrapping and
 `OpenFHE.EvalSum` generated in the functions [`init_multiplication!`](@ref),
 [`init_rotation!`](@ref), [`init_bootstrapping!`](@ref) and `OpenFHE.EvalSumKeyGen`.
 
 In the source code of OpenFHE C++, all `CryptoContext`s and keys are stored in static objects.
-Without using `cleanup`, the memory allocated for these contexts and keys will only be freed after
-restarting the Julia REPL.
+Without using `release_context_memory`, the memory allocated for these contexts and keys will
+only be freed after restarting the Julia REPL.
 
 See also: [`init_multiplication!`](@ref), [`init_rotation!`](@ref), [`init_bootstrapping!`](@ref)
 """
-function cleanup()
+function release_context_memory()
     OpenFHE.ClearEvalMultKeys()
     OpenFHE.ClearEvalSumKeys()
     OpenFHE.ClearEvalAutomorphismKeys()

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -81,4 +81,6 @@ function cleanup()
     OpenFHE.ClearEvalSumKeys()
     OpenFHE.ClearEvalAutomorphismKeys()
     OpenFHE.ReleaseAllContexts()
+    
+    nothing
 end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -62,3 +62,23 @@ end
 function decrypt(secure_matrix::SecureMatrix, private_key::PrivateKey)
     decrypt_impl(secure_matrix, private_key)
 end
+
+"""
+    cleanup()
+
+Release all `OpenFHE.CryptoContext`s and keys for multiplication, rotation, bootstrapping, and
+`OpenFHE.EvalSum` generated in the functions [`init_multiplication!`](@ref),
+[`init_rotation!`](@ref), [`init_bootstrapping!`](@ref) and `OpenFHE.EvalSumKeyGen`.
+
+In the sorce code of OpenFHE C++, all `CryptoContext`s and keys are stored in static objects.
+Without using `cleanup`, the memory allocated for these contexts and keys will only be freed after
+restarting the Julia REPL.
+
+See also: [`init_multiplication!`](@ref), [`init_rotation!`](@ref), [`init_bootstrapping!`](@ref)
+"""
+function cleanup()
+    OpenFHE.ClearEvalMultKeys()
+    OpenFHE.ClearEvalSumKeys()
+    OpenFHE.ClearEvalAutomorphismKeys()
+    OpenFHE.ReleaseAllContexts()
+end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -66,11 +66,11 @@ end
 """
     cleanup()
 
-Release all `OpenFHE.CryptoContext`s and keys for multiplication, rotation, bootstrapping, and
+Release all `OpenFHE.CryptoContext`s and keys for multiplication, rotation, bootstrapping and
 `OpenFHE.EvalSum` generated in the functions [`init_multiplication!`](@ref),
 [`init_rotation!`](@ref), [`init_bootstrapping!`](@ref) and `OpenFHE.EvalSumKeyGen`.
 
-In the sorce code of OpenFHE C++, all `CryptoContext`s and keys are stored in static objects.
+In the source code of OpenFHE C++, all `CryptoContext`s and keys are stored in static objects.
 Without using `cleanup`, the memory allocated for these contexts and keys will only be freed after
 restarting the Julia REPL.
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,5 +3,5 @@ OpenFHE = "77ce9b8e-ecf5-45d1-bd8a-d31f384f2f95"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-OpenFHE = "0.1"
+OpenFHE = "0.1.11"
 Test = "1"

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -213,6 +213,8 @@ for backend in ((; name = "OpenFHE", BackendT = OpenFHEBackend, context = contex
             @test_nowarn show(stdout, private_key)
             println()
         end
+
+        cleanup()
     end
 end
 

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -215,6 +215,7 @@ for backend in ((; name = "OpenFHE", BackendT = OpenFHEBackend, context = contex
         end
 
         release_context_memory()
+        GC.gc()
     end
 end
 

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -214,7 +214,7 @@ for backend in ((; name = "OpenFHE", BackendT = OpenFHEBackend, context = contex
             println()
         end
 
-        cleanup()
+        release_context_memory()
     end
 end
 


### PR DESCRIPTION
This PR adds function `cleanup`, that can be used for runtime cleaning of `CryptoContext`s and generated keys.

It should be merged after https://github.com/hpsc-lab/openfhe-julia/pull/61 and https://github.com/hpsc-lab/OpenFHE.jl/pull/64 and new releases of OpenFHE and openfhe-julia